### PR TITLE
Allow 0.14.x - 15.0.y

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,13 +29,13 @@
     "jsdom": "^8.4.0",
     "mocha": "^2.4.5",
     "nyc": "^6.4.0",
-    "react": "^15.0.1",
-    "react-addons-test-utils": "^15.0.1",
-    "react-dom": "^15.0.1"
+    "react": "^0.14.0 || ^15.0.0-0",
+    "react-addons-test-utils": "^0.14.0 || ^15.0.0-0",
+    "react-dom": "^0.14.0 || ^15.0.0-0"
   },
   "peerDependencies": {
-    "react": "^15.0.1",
-    "react-dom": "^15.0.1"
+    "react": "^0.14.0 || ^15.0.0-0",
+    "react-dom": "^0.14.0 || ^15.0.0-0"
   },
   "dependencies": {
     "codemirror": "^5.14.2",


### PR DESCRIPTION
Allow use of React 0.14 for notebook-preview since we're not using any React 15 specific features (only one I can think we'd use here is returning `null` from a stateless component).