### PR TITLE
import from NotebookPreview, since it's an ES6 exp

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,6 @@
 Lightweight preview of a notebook, nteract style
 
 ```js
-const NotebookPreview = require('notebook-preview');
+import NotebookPreview from 'notebook-preview';
 ReactDOM.render(<NotebookPreview notebook={notebookJSON}/>, document.querySelector('nb'));
 ```


### PR DESCRIPTION
The instructions in the README were false, since this was done as a `export default...`