### PR TITLE
Bring on base styles for publication, bump deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,9 +41,9 @@
     "codemirror": "^5.14.2",
     "commutable": "^0.6.0",
     "react-codemirror": "^0.2.6",
-    "react-jupyter-display-area": "^0.4.0",
+    "react-jupyter-display-area": "^0.4.1",
     "remark": "^4.2.2",
     "remark-react": "^2.0.0",
-    "transformime-react": "^0.6.0"
+    "transformime-react": "^0.6.1"
   }
 }

--- a/styles/main.css
+++ b/styles/main.css
@@ -1,0 +1,354 @@
+/*
+  App
+ */
+:root {
+  --prompt-width: 50px;
+}
+
+#app {
+  padding-top: 20px;
+}
+
+/*
+  Globals
+ */
+
+pre
+{
+    font-size: 14px;
+    line-height: 1.21429em;
+
+    word-wrap: break-word;
+}
+
+body
+{
+    font-family: 'Source Sans Pro';
+    font-size: 16px;
+    line-height: 22px;
+    background-color: var(--main-bg-color);
+    color: var(--main-fg-color);
+}
+
+img
+{
+    display: block;
+    max-width: 100%;
+
+    margin-right: auto;
+    margin-left: auto;
+}
+
+th,
+td {
+    padding: 0.5em 1em;
+    border: 1px solid var(--primary-border);
+}
+
+/*
+  Cell
+ */
+
+.draggable-cell {
+    position: relative;
+    padding: 10px;
+}
+
+.cell-drag-handle
+{
+    position: absolute;
+    z-index: 999;
+    width: var(--prompt-width);
+    height: 100%;
+    cursor: move;
+}
+
+.cell
+{
+    position: relative;
+    background: var(--cell-bg);
+    transition: all .1s ease-in-out;
+}
+
+.cell:focus .input_area .cell_inputs,
+.cell.focused .input_area .cell_inputs
+{
+    background-color: var(--cell-bg-focus);
+}
+
+.cell_toolbar-mask
+{
+    position: absolute;
+    top: -37px;
+    right: -5px;
+    z-index: 99;
+    height: 32px;
+
+    /* Set the left padding to 50px to give users extra room to move their
+    mouse to the toolbar without causing the cell to go out of focus and thus
+    hide the toolbar before they get there. */
+    padding: 5px 5px 0px 50px;
+}
+
+.cell_toolbar
+{
+    display: inline-box;
+    background: var(--toolbar-bg);
+    box-shadow: 0 1px 2px 0 rgba(0,0,0,.50);
+}
+
+.cell_toolbar button
+{
+    display: inline-block;
+
+    width: 22px;
+    height: 20px;
+    padding: 2px 4px;
+
+    text-align: center;
+
+    border: none;
+    outline: none;
+    background: none;
+}
+
+.cell_markdown.rendered
+{
+    padding: 10px 10px 10px var(--prompt-width);
+}
+
+.cell_markdown.unrendered .CodeMirror-lines
+{
+    padding-left: var(--prompt-width);
+}
+
+.pagers
+{
+    padding: 10px var(--prompt-width) 10px var(--prompt-width);
+    background-color: var(--pager-bg);
+    word-wrap: break-word;
+}
+
+.cell_display
+{
+    word-wrap: break-word;
+    padding: 10px 10px 10px calc(var(--prompt-width) + 10px);
+}
+
+.cell_display:empty
+{
+    display:none;
+}
+
+.cell_code .input_area
+{
+    display: flex;
+    flex-direction: row;
+}
+
+.cell_code .input_area .cell_inputs
+{
+    font-family: monospace;
+    font-size: 12px;
+
+    width: var(--prompt-width);
+    padding: 9px 0;
+
+    text-align: center;
+
+    color: var(--input-color);
+    background-color: var(--pager-bg);
+
+    flex: 0 0 auto;
+}
+
+.cell_code .input_area .cell_editor
+{
+    flex: 1 1 auto;
+}
+
+.creator-hover-mask {
+  display: block;
+  position: relative;
+  overflow: visible;
+  height: 0px;
+}
+
+.creator-hover-region {
+  display: flex;
+  position: relative;
+  overflow: visible;
+  top: -30px;
+  height: 60px;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  pointer-events: none;
+}
+
+.creator-tool {
+  display: inline-block;
+  background: var(--main-bg-color);
+  box-shadow: 0 1px 2px 0 rgba(0,0,0,.50);
+  margin-top: -15px;
+  pointer-events: all;
+}
+
+.creator-tool button
+{
+  display: inline-block;
+
+  width: 22px;
+  height: 20px;
+  padding: 2px 4px;
+
+  text-align: center;
+
+  border: none;
+  outline: none;
+  background: none;
+}
+
+.creator-tool button i
+{
+  /* These icons are thin, use a larger font than the cell toolbar */
+  font-size: 17px;
+  line-height: 1;
+
+  color: var(--toolbar-button);
+}
+
+.creator-tool .creator-label {
+  color: var(--toolbar-button);
+  font-size: 12px;
+  text-transform: uppercase;
+  padding: 5px;
+  vertical-align: text-bottom;
+  font-weight: bold;
+}
+
+code {
+  font-family: 'Source Code Pro';
+  white-space: pre-wrap;
+  font-size: 14px;
+}
+
+/*
+    Codemirror
+ */
+
+.CodeMirror
+{
+    font-family: 'Source Code Pro';
+    font-size: 14px;
+    line-height: 20px;
+
+    height: auto;
+
+    background: none;
+}
+
+.CodeMirror-cursor
+{
+    border-left-width: 1px;
+    border-left-style: solid;
+    border-left-color: var(--cm-color);
+}
+
+.CodeMirror-scroll
+{
+    overflow-x: auto;
+    overflow-y: hidden;
+}
+
+.CodeMirror-lines
+{
+    padding: .4em;
+}
+
+.CodeMirror-linenumber
+{
+    padding: 0 8px 0 4px;
+}
+
+.CodeMirror-gutters
+{
+    border-top-left-radius: 2px;
+    border-bottom-left-radius: 2px;
+}
+
+.CodeMirror pre
+{
+    padding: 0;
+
+    border: 0;
+    border-radius: 0;
+}
+
+.cm-s-composition.CodeMirror {
+	font-family: 'Source Code Pro', monospace;
+	letter-spacing: 0.3px;
+	word-spacing: 1px;
+	background: var(--cm-background);
+	color: var(--cm-color);
+}
+.cm-s-composition .CodeMirror-lines {
+  padding: 10px;
+}
+.cm-s-composition .CodeMirror-gutters {
+	box-shadow: 1px 0 2px 0 rgba(0, 0, 0, 0.5);
+	-webkit-box-shadow: 1px 0 2px 0 rgba(0, 0, 0, 0.5);
+	background-color: var(--cm-gutter-bg);
+	padding-right: 10px;
+	z-index: 3;
+	border: none;
+}
+
+.cm-s-composition span.cm-comment { color: var(--cm-comment) }
+.cm-s-composition span.cm-keyword { line-height: 1em; font-weight: bold; color: var(--cm-keyword); }
+.cm-s-composition span.cm-string { color: var(--cm-string); }
+.cm-s-composition span.cm-builtin { line-height: 1em; font-weight: bold; color: var(--cm-builtin); }
+.cm-s-composition span.cm-special { line-height: 1em; font-weight: bold; color: var(--cm-special); }
+.cm-s-composition span.cm-variable { color: var(--cm-variable); }
+.cm-s-composition span.cm-number, .cm-s-composition span.cm-atom { color: var(--cm-number); }
+.cm-s-composition span.cm-meta { color: var(--cm-meta); }
+.cm-s-composition span.cm-link { color: var(--cm-link); }
+
+.cm-s-composition .CodeMirror-activeline-background { background: var(--cm-activeline-bg); }
+.cm-s-composition .CodeMirror-matchingbracket { outline:1px solid var(--cm-matchingbracket-outline); color: var(--cm-matchingbracket-color) !important; }
+
+/* Overwrite some of the hint Styling */
+
+.CodeMirror-hints {
+
+  -webkit-box-shadow: 2px 3px 5px rgba(0,0,0,.2);
+  -moz-box-shadow: 2px 3px 5px rgba(0,0,0,.2);
+  box-shadow: 2px 3px 5px rgba(0,0,0,.2);
+  border-radius: 0px;
+  border: none;
+  padding:0;
+
+  background: var(--cm-hint-bg);
+  font-size: 90%;
+  font-family: 'Source Code Pro', monospace;
+
+  overflow-y: auto;
+}
+
+.CodeMirror-hint {
+  border-radius: 0px;
+  max-width: 19em;
+  white-space: pre;
+  cursor: pointer;
+  color: var(--cm-hint-color);
+}
+
+li.CodeMirror-hint-active {
+  background: var(--cm-hint-bg-active);
+  color: var(--cm-hint-color-active);
+}
+
+
+.CodeMirror-cursor {
+  display: none;
+}

--- a/styles/theme-dark.css
+++ b/styles/theme-dark.css
@@ -1,0 +1,41 @@
+:root {
+  --main-bg-color: #2b2b2b;
+  --main-fg-color: #ccc;
+
+  --primary-border: #cbcbcb;
+
+  --cell-bg: #2b2b2b;
+  --cell-bg-hover: #151515;
+  --cell-bg-focus: #1f1f1f;
+
+  --toolbar-bg: #2b2b2b;
+  --toolbar-button: #aaa;
+  --toolbar-button-hover: #555;
+
+  --pager-bg: #111;
+  --input-color: #fafafa;
+
+  --cm-background: #111;
+  --cm-color: #ecf0f1;
+
+  --cm-gutter-bg: #777;
+
+  --cm-comment: #777;
+  --cm-keyword: #3498db;
+  --cm-string: #f1c40f;
+  --cm-builtin: #16a085;
+  --cm-special: #1abc9c;
+  --cm-variable: #ecf0f1;
+  --cm-number: #2ecc71;
+  --cm-meta: #95a5a6;
+  --cm-link: #2ecc71;
+
+  --cm-activeline-bg: #e8f2ff;
+  --cm-matchingbracket-outline: grey;
+  --cm-matchingbracket-color: white;
+
+  --cm-hint-color: var(--main-fg-color);
+  --cm-hint-color-active: var(--cm-color);
+  --cm-hint-bg: var(--main-bg-color);
+  --cm-hint-bg-active: var(--pager-bg);
+}

--- a/styles/theme-light.css
+++ b/styles/theme-light.css
@@ -1,0 +1,41 @@
+:root {
+  --main-bg-color: white;
+  --main-fg-color: rgb(51,51,51);
+
+  --primary-border: #cbcbcb;
+
+  --cell-bg: white;
+  --cell-bg-hover: #eeedee;
+  --cell-bg-focus: #e2dfe3;
+
+  --toolbar-bg: white;
+  --toolbar-button: #aaa;
+  --toolbar-button-hover: #555;
+
+  --pager-bg: #fafafa;
+  --input-color: #8c8a8e;
+
+  --cm-background: #fafafa;
+  --cm-color: black;
+
+  --cm-gutter-bg: white;
+
+  --cm-comment: #a86;
+  --cm-keyword: blue;
+  --cm-string: #a22;
+  --cm-builtin: #077;
+  --cm-special: #0aa;
+  --cm-variable: black;
+  --cm-number: #3a3;
+  --cm-meta: #555;
+  --cm-link: #3a3;
+
+  --cm-activeline-bg: #e8f2ff;
+  --cm-matchingbracket-outline: grey;
+  --cm-matchingbracket-color: black;
+
+  --cm-hint-color: var(--cm-color);
+  --cm-hint-color-active: var(--cm-color);
+  --cm-hint-bg: var(--main-bg-color);
+  --cm-hint-bg-active: #ABD1FF;
+}


### PR DESCRIPTION
Include some basic styling that someone can package for deployment. A user of this package will also need to `<link>` the codemirror CSS, optionally including normalize.css and the `source-*-pro` fonts. Example CSS requirement:

```html
<link rel="stylesheet" href="node_modules/normalize.css/normalize.css"/>
<link rel="stylesheet" href="node_modules/codemirror/lib/codemirror.css"/>
<link href='https://fonts.googleapis.com/css?family=Source+Code+Pro:400,700,300,200,500,600,900' rel='stylesheet' type='text/css'>
<link href='https://fonts.googleapis.com/css?family=Source+Sans+Pro:400,200,200italic,300,300italic,400italic,600,600italic,700,700italic,900,900italic' rel='stylesheet' type='text/css'>
<link rel="stylesheet" href="node_modules/notebook-preview/styles/theme-light.css" />
<link rel="stylesheet" href="node_modules/notebook-preview/styles/main.css" />
```

As for nteract's CSS, we need to hone in on our overall structure so we can create themes, show others how to create themes, and generally have a path forward for maintainability.

/cc @captainsafia 