### PR TITLE
Check if notebook prop is null

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -5,9 +5,13 @@ import * as commutable from 'commutable';
 import Immutable from 'immutable';
 
 const NotebookPreview = (props) => {
-  const nb = props.notebook;
-  const notebook = Immutable.Map.isMap(nb) ? nb : commutable.fromJS(nb);
-  return <Notebook notebook={notebook} />;
+  if (props.notebook) {
+    const nb = props.notebook;
+    const notebook = Immutable.Map.isMap(nb) ? nb : commutable.fromJS(nb);
+    return <Notebook notebook={notebook} />;
+  } else {
+    return <h1>Notebook not provided. </h1>;
+  }
 };
 
 NotebookPreview.propTypes = {


### PR DESCRIPTION
I need this to get notebook-preview-demo to work.

Namely, the NotebookPreview component should not fail to render if the notebook JSON is invalid or missing. It should just render an error message (I think this is the right way to do it).