### PR TITLE
Scope CSS that should only be in our cells

### DIFF
--- a/styles/main.css
+++ b/styles/main.css
@@ -13,7 +13,7 @@
   Globals
  */
 
-pre
+.cell pre
 {
     font-size: 14px;
     line-height: 1.21429em;
@@ -30,7 +30,7 @@ body
     color: var(--main-fg-color);
 }
 
-img
+.cell img
 {
     display: block;
     max-width: 100%;
@@ -39,8 +39,8 @@ img
     margin-left: auto;
 }
 
-th,
-td {
+.cell th,
+.cell td {
     padding: 0.5em 1em;
     border: 1px solid var(--primary-border);
 }


### PR DESCRIPTION
This scopes some global CSS to only match when inside a `.cell`. In the long term we're going to want to be a bit more explicit (or even nest styling per component). This should help commuter for the time being.